### PR TITLE
Upon chase/conway

### DIFF
--- a/src/Clb/Era.hs
+++ b/src/Clb/Era.hs
@@ -9,23 +9,6 @@ import Cardano.Ledger.Api qualified as L
 import Cardano.Ledger.Shelley.API
 import Data.Default (Default)
 
--- This is available in newer cardano-api. Remove this once we depend on that.
-class IsShelleyBasedEra era => IsMaryBasedEra era where
-  maryBasedEra :: MaryEraOnwards era
-
-instance IsMaryBasedEra MaryEra where
-  maryBasedEra = MaryEraOnwardsMary
-
-instance IsMaryBasedEra AlonzoEra where
-  maryBasedEra = MaryEraOnwardsAlonzo
-
-instance IsMaryBasedEra BabbageEra where
-  maryBasedEra = MaryEraOnwardsBabbage
-
-instance IsMaryBasedEra ConwayEra where
-  maryBasedEra = MaryEraOnwardsConway
-
-
 -- | Helper class for constraining the 'CardanoLedgerEra' closed type family.
 -- Ensures user chosen era (from Cardano.Api.Eras) is valid for usage with CLB.
 class ( ledgerEra ~ CardanoLedgerEra era

--- a/src/Clb/Era.hs
+++ b/src/Clb/Era.hs
@@ -18,10 +18,7 @@ class ( ledgerEra ~ CardanoLedgerEra era
       , ApplyTx ledgerEra
       , Default (L.GovState ledgerEra)
       , Show (L.GovState ledgerEra)
-      -- The 'IsShelleyBasedEra' constraint may seem redundant with our implementation of 'IsMaryBasedEra', but said constraint
-      -- is missing on the upstream 'IsMaryBasedEra' in newer cardano-api. So if we use the upstream class later, we should uncomment
-      -- this constraint.
-      -- , IsShelleyBasedEra era
+      , IsShelleyBasedEra era
       , IsMaryBasedEra era
       )
       => IsCardanoLedgerEra' era ledgerEra | era -> ledgerEra where

--- a/src/Clb/Params.hs
+++ b/src/Clb/Params.hs
@@ -20,6 +20,7 @@ import Data.Either (fromRight)
 import Data.Functor.Identity (Identity)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
+import Test.Cardano.Ledger.Plutus qualified as LT (testingCostModelV3)
 
 type PParams era = L.PParams (CardanoLedgerEra era)
 
@@ -136,6 +137,7 @@ defaultConwayParams =
             , ucppDRepActivity               = L.EpochInterval 20
             , ucppCommitteeMinSize           = 0
             , ucppCommitteeMaxTermLength     = L.EpochInterval 73
+            , ucppPlutusV3CostModel          = LT.testingCostModelV3  -- FIXME: This is temporary.
             } defaultBabbageParams
    in coerce $
         old


### PR DESCRIPTION
Not to be merged, this is done in sync with getting [Atlas ready for Conway](https://github.com/geniusyield/atlas/pull/327).
In particular `ucppPlutusV3CostModel` need to specified correctly (if not already).