### PR TITLE
Last never-forking era, get chain points query

### DIFF
--- a/emulator/src/Cardano/Node/Socket/Emulator/Query.hs
+++ b/emulator/src/Cardano/Node/Socket/Emulator/Query.hs
@@ -57,6 +57,7 @@ import Ouroboros.Consensus.HardFork.History.Summary (
   Bound (..),
   EraSummary (..),
   Summary (..),
+  neverForksSummary,
  )
 import Ouroboros.Consensus.Ledger.Query (Query (..))
 import Ouroboros.Consensus.Protocol.Praos (Praos)
@@ -176,7 +177,7 @@ emulatorEraHistory params = C.EraHistory (Ouroboros.mkInterpreter $ Ouroboros.su
     lastS =
       Ouroboros.nonEmptyHead $
         Ouroboros.getSummary $
-          skipSummary lastEndBound emulatorEpochSize (slotLength params) emulatorGenesisWindow
+          neverForksSummary emulatorEpochSize (slotLength params) emulatorGenesisWindow
     list = Ouroboros.Exactly $ K one :* K one :* K one :* K one :* K one :* K one :* K lastS :* Nil
 
 -- | 'Summary' for a ledger that never forks
@@ -195,14 +196,6 @@ skipSummary endBound epochSize slotLen genesisWindow =
               , eraGenesisWin = genesisWindow
               }
         }
-
-lastEndBound :: Bound
-lastEndBound =
-  Bound
-    { boundTime = RelativeTime 50
-    , boundSlot = SlotNo 1
-    , boundEpoch = EpochNo 500
-    }
 
 emulatorGenesisWindow :: GenesisWindow
 emulatorGenesisWindow = GenesisWindow window

--- a/emulator/src/Cardano/Node/Socket/Emulator/Query.hs
+++ b/emulator/src/Cardano/Node/Socket/Emulator/Query.hs
@@ -18,13 +18,14 @@ import Cardano.Node.Socket.Emulator.Types (
   AppState (..),
   EmulatorMsg,
   clbState,
+  getChainPointTime,
   getTip,
   runClbInIO',
   socketEmulatorState,
  )
 import Cardano.Slotting.EpochInfo (epochInfoEpoch)
 import Cardano.Slotting.Slot (WithOrigin (..))
-import Cardano.Slotting.Time (RelativeTime (RelativeTime), SlotLength, mkSlotLength)
+import Cardano.Slotting.Time (SlotLength, mkSlotLength)
 import Clb (ClbT, chainState, clbConfig, getClbConfig, getCurrentSlot, getGlobals, getStakePools, getUtxosAt)
 import Clb qualified as E
 import Clb.Config (ClbConfig (..))
@@ -47,7 +48,7 @@ import Data.SOP.Counting qualified as Ouroboros
 import Data.SOP.NonEmpty qualified as Ouroboros
 import Data.SOP.Strict (NP (Nil, (:*)), NS (S, Z))
 import Data.Set qualified as Set
-import Ouroboros.Consensus.Block (EpochNo (EpochNo), EpochSize, GenesisWindow (..), SlotNo (SlotNo))
+import Ouroboros.Consensus.Block (EpochSize, GenesisWindow (..))
 import Ouroboros.Consensus.Cardano.Block (BlockQuery (..), CardanoBlock)
 import Ouroboros.Consensus.HardFork.Combinator (QueryHardFork (..))
 import Ouroboros.Consensus.HardFork.Combinator qualified as Consensus
@@ -123,7 +124,11 @@ handleQueryConwayEra trace state q =
             let ret = At curBlockNo
             logInfo $ "Tip is: " <> show ret
             pure ret
-      GetChainPoint -> printError "Unimplemented GetChainPoint was received"
+      query@GetChainPoint -> do
+        logInfo $ "Query was received (5): " ++ show query
+        ret <- getChainPointTime state
+        logInfo $ "Chain point time is: " <> show ret
+        pure ret
 
 queryIfCurrentConway ::
   (block ~ Shelley.ShelleyBlock (Praos StandardCrypto) (ConwayEra StandardCrypto)) =>


### PR DESCRIPTION
For the last era to be usable we have to omit the `end` field, indicating that there is no hard fork expected and the era will last forever. An alternative option would be to provide some sensible defaults the way cardano-testnet does, though it's required.

Also, this PR contains some fixes needed to run bet-ref using CTL: see https://github.com/Plutonomicon/cardano-transaction-lib/pull/1655 